### PR TITLE
fix Crystal with map implementation

### DIFF
--- a/crystal/with_map.cr
+++ b/crystal/with_map.cr
@@ -31,15 +31,15 @@ def indexing_lessons(lessons : Array)
   lessons.map_with_index(1) { |lesson, index| lesson.merge({ position: index}) }
 end
 
-selected_lessons = sections.map { |section| section[:lessons] }.flatten
+selected_lessons = sections.flat_map(&.[:lessons])
 indexed_lessons = indexing_lessons(selected_lessons)
 
-formated_section = sections.map do |section|
+formated_section = sections.map_with_index(1) do |section, i|
   formated_lessons = indexed_lessons.shift(section[:lessons].size)
   if section[:reset_lesson_position]
     formated_lessons = indexing_lessons(section[:lessons])
   end
-  section.merge(lessons: formated_lessons)
+  section.merge(position: i, lessons: formated_lessons)
 end
 
-p formated_section
+pp formated_section


### PR DESCRIPTION
Hi @jvelez1 .

I fixed your implementation. You missed `position for sections.

Also, it's recommended to use `flat_map {...}` instead of `map {...}.flatten`

Output:

```
[{title: "Getting started",
  reset_lesson_position: false,
  position: 1,
  lessons: 
   [{name: "Welcome", position: 1}, {name: "Installation", position: 2}]},
 {title: "Basic operator",
  reset_lesson_position: false,
  position: 2,
  lessons: 
   [{name: "Addition / Subtraction", position: 3},
    {name: "Multiplication / Division", position: 4}]},
 {title: "Advanced topics",
  reset_lesson_position: true,
  position: 3,
  lessons: 
   [{name: "Mutability", position: 1}, {name: "Immutability", position: 2}]}]
```