### PR TITLE
Rust: sideeffect-free solution using enumerate and fold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-
-tags
-rust/Cargo.lock
-rust/Cargo.toml
-rust/target

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+tags
+rust/Cargo.lock
+rust/Cargo.toml
+rust/target

--- a/rust/enumerate-fold.rs
+++ b/rust/enumerate-fold.rs
@@ -1,0 +1,95 @@
+#[derive(Debug, Clone)]
+struct Lesson {
+    name: String,
+    position: Option<u32>,
+}
+
+#[derive(Debug, Clone)]
+struct Section {
+    title: String,
+    reset_position_title: bool,
+    lessons: Vec<Lesson>,
+    position: Option<usize>,
+}
+
+fn main() {
+    let sections: Vec<Section> = vec![
+        Section {
+            title: String::from("Getting started"),
+            reset_position_title: false,
+            lessons: vec![
+                Lesson {
+                    name: String::from("Welcome"),
+                    position: None,
+                },
+                Lesson {
+                    name: String::from("Installation"),
+                    position: None,
+                },
+            ],
+            position: None,
+        },
+        Section {
+            title: String::from("Basic operator"),
+            reset_position_title: false,
+            lessons: vec![
+                Lesson {
+                    name: String::from("Addition / Subtraction"),
+                    position: None,
+                },
+                Lesson {
+                    name: String::from("Multiplication / Division"),
+                    position: None,
+                },
+            ],
+            position: None,
+        },
+        Section {
+            title: String::from("Advanced topics"),
+            reset_position_title: true,
+            lessons: vec![
+                Lesson {
+                    name: String::from("Mutability"),
+                    position: None,
+                },
+                Lesson {
+                    name: String::from("Immutability"),
+                    position: None,
+                },
+            ],
+            position: None,
+        },
+    ];
+
+    let formatted_sections =
+        sections
+            .iter()
+            .enumerate()
+            .try_fold(Vec::<Section>::new(), |mut acc, (idx, s)| {
+                let lesson_position = if s.reset_position_title || acc.is_empty() {
+                    1
+                } else {
+                    acc.last()?.lessons.last()?.position? + 1
+                };
+
+                acc.push(Section {
+                    lessons: s
+                        .lessons
+                        .iter()
+                        .zip(lesson_position..)
+                        .map(|(l, p)| Lesson {
+                            position: Some(p),
+                            name: l.name.clone(),
+                            ..*l
+                        })
+                        .collect(),
+                    title: s.title.clone(),
+                    position: Some(idx + 1),
+                    ..*s
+                });
+
+                Some(acc)
+            });
+
+    println!("{:?}", formatted_sections.unwrap());
+}

--- a/rust/map-mutable.rs
+++ b/rust/map-mutable.rs
@@ -1,8 +1,10 @@
+#[derive(Debug)]
 struct Lesson {
     name: String,
     position: Option<u32>,
 }
 
+#[derive(Debug)]
 struct Section {
     title: String,
     reset_position_title: bool,
@@ -23,7 +25,7 @@ fn main() {
                 Lesson {
                     name: String::from("Installation"),
                     position: None,
-                }
+                },
             ],
             position: None,
         },
@@ -53,36 +55,44 @@ fn main() {
                 Lesson {
                     name: String::from("Immutability"),
                     position: None,
-                }
+                },
             ],
             position: None,
-        }
+        },
     ];
-    
+
     let mut section_position = 0;
     let mut lesson_position = 0;
 
-    let formatted_sections: Vec<Section> = sections.iter().map(|s| {
-        if s.reset_position_title == true {
-            lesson_position = 0;
-        }
+    let formatted_sections: Vec<Section> = sections
+        .iter()
+        .map(|s| {
+            if s.reset_position_title == true {
+                lesson_position = 0;
+            }
 
-        section_position += 1;
+            section_position += 1;
 
-        Section {
-            lessons: s.lessons.iter().map(|l| {
-                lesson_position += 1;
+            Section {
+                lessons: s
+                    .lessons
+                    .iter()
+                    .map(|l| {
+                        lesson_position += 1;
 
-                Lesson {
-                    position: Some(lesson_position),
-                    name: l.name.clone(),
-                    ..*l
-                }
-            }).collect(),
-            title: s.title.clone(),
-            position: Some(section_position),
-            ..*s
-        }
-    }).collect();
+                        Lesson {
+                            position: Some(lesson_position),
+                            name: l.name.clone(),
+                            ..*l
+                        }
+                    })
+                    .collect(),
+                title: s.title.clone(),
+                position: Some(section_position),
+                ..*s
+            }
+        })
+        .collect();
+
+    println!("{:?}", formatted_sections);
 }
-


### PR DESCRIPTION
Submitting a Rust solution that is still mutable in its nature but is (effectively) side-effect-free by folding an enumerated iterator of sections instead of relying on mutable variables external to the main "loop", all while being a bit shorter than the original.

I also took the liberty of formatting the original solution to make it conform to the Rust community guidelines for code style and to make it easier to compare both solutions. /cc @panther99 