### PR TITLE
Tcl: replace [dict getdef] with simple [dict get]

### DIFF
--- a/tcl/lmap.tcl
+++ b/tcl/lmap.tcl
@@ -1,7 +1,5 @@
 #! /usr/bin/env tclsh
-# This code uses [dict getdef], currently a cutting edge feature.  It has been
-# tested in Tcl 8.7a3 and Jim Tcl 0.80.  See
-# https://core.tcl-lang.org/tips/doc/trunk/tip/342.md
+# Tested with Tcl 8.6 and Jim Tcl 0.80.
 
 set sections {
     {
@@ -34,7 +32,7 @@ set lessonCounter 1
 set sectionCounter 1
 
 puts [lmap section $sections {
-    if {[dict getdef $section reset_lesson_position false]} {
+    if {[dict get $section reset_lesson_position]} {
         set lessonCounter 1
     }
 


### PR DESCRIPTION
Oops, for some reason I wrote a solution that handles `reset_lesson_position` missing.  (A reflex from working with bad data?)  Since we actually don't need to, we can get rid of the `dict getdef` and gain compatibility with non-cutting-edge Tcl.  The file is renamed to reflect the removal of `getdef`.