### PR TITLE
Reset section_counter too

### DIFF
--- a/python/for-in.py
+++ b/python/for-in.py
@@ -31,6 +31,7 @@ lesson_counter = 1
 for section in sections:
     if section["reset_lesson_position"]:
         lesson_counter = 1
+        section_counter = 1
 
     section["position"] = section_counter
     section_counter += 1


### PR DESCRIPTION
Hi there! While reading the read.me, I thought I spotted an error in the provided python solution (for-in.py). Sure enough, it seems to be missing a reset (to 1) of section_counter. 

Without a section_counter reset in the if statement, the last section listed a position of 3. Seemingly, the expected value is 1 since this section triggers a reset to both lesson and section counters.

Maybe that was inconsequential, but I made a github account to propose a change.

Cheers!