### PR TITLE
Add a common lisp solution using LOOP.

### DIFF
--- a/common-lisp/loop.lisp
+++ b/common-lisp/loop.lisp
@@ -1,0 +1,36 @@
+(let ((sample (list
+               (list
+                'title "Getting started"
+                'reset_lesson_position nil
+                'lessons (list
+                          (list 'name "Welcome")
+                          (list 'name "Installation")
+                          )
+                )
+
+               (list
+                'title "Basic operator"
+                'reset_lesson_position nil
+                'lessons (list
+                          (list 'name "Addition / Subtraction")
+                          (list 'name "Multiplication / Division")
+                          )
+                )
+
+               (list
+                'title "Advanced topics"
+                'reset_lesson_position t
+                'lessons (list
+                          (list 'name "Mutability")
+                          (list 'name "Immutability")
+                          )
+                )
+               )))
+
+  (loop for section in sample
+        for curLevel = 1 then (if (getf section 'reset_lesson_position) 1 curLevel)
+        do (loop for lesson in (getf section 'lessons)
+                 do (progn (nconc lesson (list 'position curLevel))
+                          (setq curLevel (1+ curLevel)))))
+
+  sample)


### PR DESCRIPTION
More than a bit more imperative than might be expected from LISP.  I can't
make legitimate claims that this is idiomatic, but it is the first that
came to mind on how I'd do this with lisp.  (I confess this came a bit more
naturally in elisp, but alas.)

This does have a bit of a feel that I was going for code golf, but I argue
against that idea.  This is the natural result of treating the data as a
nested set of plists.  If this was something that was to be more long
lived, I think it would naturally extend to some defstructs, but the
general loop would remain the same.

<!--

Thanks for showing interest in submitting a solution!

New solutions to the problem are welcome. In order to contribute:

* Make sure there are no entries for your programming language of choice
* If there are existing entries, make sure your proposed solution is considerably distinct

For example, avoid new entries that are small variations of existing solutions.
Solutions that use different approaches, such as mutability vs immutability,
single-pass vs chunking, etc are all welcome though.

-->
