### PR TITLE
Update SML example to use foldmap and other minor improvements

### DIFF
--- a/sml/foldl_immutable_records.sml
+++ b/sml/foldl_immutable_records.sml
@@ -24,20 +24,17 @@ val sections : section list = [
     ]
 ]
 
-fun withPositions (sections : section list) =
-    (rev o #1 o positionSections) sections
 
-and positionSections sections =
-    List.foldl positionSection ([], 1, 1) sections
+fun withPositions sections =
+    let val (revSections, _, _) = List.foldl positionSection ([], 1, 1) sections
+    in  rev revSections
+    end
 
 and positionSection (section as { title, reset_lesson_position, lessons, ... }, (revSections, secPos, lessPos)) =
     let val lessPos = (if reset_lesson_position then 1 else lessPos)
-        val (revLessons, lessPos) = positionLessons lessPos lessons in
+        val (revLessons, lessPos) = List.foldl positionLesson ([], lessPos) lessons in
         (setPosLessons secPos (rev revLessons) section :: revSections, secPos + 1, lessPos)
     end
-
-and positionLessons start lessons =
-    List.foldl positionLesson ([], start) lessons
 
 and positionLesson (lesson, (revLessons, lessPos)) =
     (setPos lessPos lesson :: revLessons, lessPos + 1)

--- a/sml/foldl_immutable_records.sml
+++ b/sml/foldl_immutable_records.sml
@@ -1,13 +1,13 @@
-type lesson  = { position: int option, name: string }
-type section = { position: int option, title: string, reset_lesson_position: bool, lessons: lesson list }
+type lesson  = {position: int option, name: string}
+type section = {position: int option, title: string, resetLessonPosition: bool, lessons: lesson list}
 
-fun mkSection title reset lessons = { position=NONE, title=title, reset_lesson_position=reset, lessons=lessons }
-fun mkLesson name                 = { position=NONE, name=name }
+fun mkSection title reset lessons = {position = NONE, title = title, resetLessonPosition = reset, lessons = lessons}
+fun mkLesson name                 = {position = NONE, name = name}
 
-fun setPosLessons pos lessons ({title, reset_lesson_position, ...} : section) =
-    { position=SOME pos, lessons=lessons, title=title, reset_lesson_position=reset_lesson_position }
-fun setPos pos ({name, ...} : lesson) =
-    { position=SOME pos, name=name }
+fun updateSection pos lessons ({title, resetLessonPosition, ...} : section) =
+    {position = SOME pos, lessons = lessons, title = title, resetLessonPosition = resetLessonPosition}
+fun updateLesson pos ({name, ...} : lesson) =
+    {position = SOME pos, name = name}
 
 val sections : section list = [
     mkSection "Getting started" false [
@@ -30,14 +30,14 @@ fun withPositions sections =
     in  rev revSections
     end
 
-and positionSection (section as { title, reset_lesson_position, lessons, ... }, (revSections, secPos, lessPos)) =
-    let val lessPos = (if reset_lesson_position then 1 else lessPos)
-        val (revLessons, lessPos) = List.foldl positionLesson ([], lessPos) lessons in
-        (setPosLessons secPos (rev revLessons) section :: revSections, secPos + 1, lessPos)
+and positionSection (section as {title, resetLessonPosition, lessons, ...}, (revSections, secPos, lessPos)) =
+    let val lessPos'1 = if resetLessonPosition then 1 else lessPos
+        val (revLessons, lessPos') = List.foldl positionLesson ([], lessPos'1) lessons
+    in  (updateSection secPos (rev revLessons) section :: revSections, secPos + 1, lessPos')
     end
 
 and positionLesson (lesson, (revLessons, lessPos)) =
-    (setPos lessPos lesson :: revLessons, lessPos + 1)
+    (updateLesson lessPos lesson :: revLessons, lessPos + 1)
 
 
 val sections' = withPositions sections

--- a/sml/foldl_immutable_records.sml
+++ b/sml/foldl_immutable_records.sml
@@ -38,3 +38,6 @@ and positionSection (section as { title, reset_lesson_position, lessons, ... }, 
 
 and positionLesson (lesson, (revLessons, lessPos)) =
     (setPos lessPos lesson :: revLessons, lessPos + 1)
+
+
+val sections' = withPositions sections

--- a/sml/foldl_immutable_records.sml
+++ b/sml/foldl_immutable_records.sml
@@ -25,19 +25,19 @@ val sections : section list = [
 ]
 
 fun withPositions (sections : section list) =
-    (#1 o positionSections) sections
+    (rev o #1 o positionSections) sections
 
 and positionSections sections =
     List.foldl positionSection ([], 1, 1) sections
 
-and positionSection (section as { title, reset_lesson_position, lessons, ... }, (sections, secPos, lessPos)) =
+and positionSection (section as { title, reset_lesson_position, lessons, ... }, (revSections, secPos, lessPos)) =
     let val lessPos = (if reset_lesson_position then 1 else lessPos)
-        val (lessons, lessPos) = positionLessons lessPos lessons in
-        (sections @ [setPosLessons secPos lessons section], secPos + 1, lessPos)
+        val (revLessons, lessPos) = positionLessons lessPos lessons in
+        (setPosLessons secPos (rev revLessons) section :: revSections, secPos + 1, lessPos)
     end
 
 and positionLessons start lessons =
     List.foldl positionLesson ([], start) lessons
 
-and positionLesson (lesson, (lessons, lessPos)) =
-    (lessons @ [setPos lessPos lesson], lessPos + 1)
+and positionLesson (lesson, (revLessons, lessPos)) =
+    (setPos lessPos lesson :: revLessons, lessPos + 1)

--- a/sml/foldl_immutable_records.sml
+++ b/sml/foldl_immutable_records.sml
@@ -4,9 +4,9 @@ type section = { position: int option, title: string, reset_lesson_position: boo
 fun mkSection title reset lessons = { position=NONE, title=title, reset_lesson_position=reset, lessons=lessons }
 fun mkLesson name                 = { position=NONE, name=name }
 
-fun setPosLessons pos lessons {title, reset_lesson_position, ...} =
+fun setPosLessons pos lessons ({title, reset_lesson_position, ...} : section) =
     { position=SOME pos, lessons=lessons, title=title, reset_lesson_position=reset_lesson_position }
-fun setPos pos {name, ...} =
+fun setPos pos ({name, ...} : lesson) =
     { position=SOME pos, name=name }
 
 val sections : section list = [

--- a/sml/foldmapl_immutable_records.sml
+++ b/sml/foldmapl_immutable_records.sml
@@ -1,0 +1,57 @@
+type lesson  = {position: int option, name: string}
+type section = {position: int option, title: string, resetLessonPosition: bool, lessons: lesson list}
+
+fun mkSection title reset lessons = {position = NONE, title = title, resetLessonPosition = reset, lessons = lessons}
+fun mkLesson name                 = {position = NONE, name = name}
+
+fun updateSection pos lessons ({title, resetLessonPosition, ...} : section) =
+    {position = SOME pos, lessons = lessons, title = title, resetLessonPosition = resetLessonPosition}
+fun updateLesson pos ({name, ...} : lesson) =
+    {position = SOME pos, name = name}
+
+val sections : section list = [
+    mkSection "Getting started" false [
+        mkLesson "Welcome",
+        mkLesson "Installation"
+    ],
+    mkSection "Basic operator" false [
+        mkLesson "Addition / Subtraction",
+        mkLesson "Multiplication / Division"
+    ],
+    mkSection "Advanced topics" true [
+        mkLesson "Mutability",
+        mkLesson "Immutability"
+    ]
+]
+
+
+(* Define a fold-map utility function.
+ * `foldMapl` is proposed for the SML Basis Library - see
+ * https://github.com/SMLFamily/BasisLibrary/wiki/2015-003b-List
+ * The definition below is from the section Discussion.
+ *)
+fun foldMapl f init xs =
+  let
+    fun f' (x, (ys, r)) = let val (y, r) = f (x, r) in (y :: ys, r) end
+    val (ys, r) = List.foldl f' ([], init) xs
+  in
+    (List.rev ys, r)
+  end
+
+
+fun withPositions sections =
+    let val (sections', _) = foldMapl positionSection (1, 1) sections
+    in  sections'
+    end
+
+and positionSection (section as {title, resetLessonPosition, lessons, ...}, (secPos, lessPos)) =
+    let val lessPos'1 = if resetLessonPosition then 1 else lessPos
+        val (lessons', lessPos') = foldMapl positionLesson lessPos'1 lessons
+    in  (updateSection secPos lessons' section, (secPos + 1, lessPos'))
+    end
+
+and positionLesson (lesson, lessPos) =
+    (updateLesson lessPos lesson, lessPos + 1)
+
+
+val sections' = withPositions sections


### PR DESCRIPTION
Here are some improvements to the SML example.

@fabjan - as you created the original example, please let us know whether you agree with the observations below.  One option is to add this as a separate example, but I think items 1 and 2 would still need to be addressed.  Note that the first commit addresses item in the original example.

 1. The code doesn't type check with SML/NJ.  Some explicit type annotations are required.  This is because SML/NJ uses a smaller scope than needed to resolve the types of flexible records.  (The Definition of SML is too lax about scope used to resolve flexible records, which is a known defect.)
 1. `xs @ [...]` is generally leads to O(n^2) behaviour because an entire new list is being created on each recursion.  This is avoided by extending the result of the inner recursion, which is achieved by storing the list in revserse.  However this is taken care of by `foldMapl` - see next comment.
 1. The nature of the problem is really a fold-map - a simultaneous fold and map.  Unfortunately the Basis Library did not provide such a combinator but most people write their own, so much so that it is now proposed for the Basis Library:
    https://github.com/SMLFamily/BasisLibrary/wiki/2015-003b-List
    The definition given above is as per the discussion section in that page.
 1. Once `foldMapl` is used, functions `positionLessons` and `positionSections` are not really needed anymore.
 1. Functions aren't mutually recursive, so separate fun bindings could be used.  I didn't change the code for this though.
 1. There is no code to evaluate `withPositions` so the code is not run.
 1. It's a good convention to avoid rebinding a function argument to avoid confusion.
    I've used `lessPos'1` instead of `lessPos`.  I tend to use a convention where
    successive versions of a value `x` have the name `x'<n>`, and the final version
    is `x'`.
 1. Inconsistent use of names: `start` vs. `lessPos`.
 1. Parentheses aren't required around an 'if' expression.
 1. For me it would be clearer to rename `setPosLessons` to `updateSection` and `setPos` to `updateLesson`.
 1. Inconsistent case convention of variables with `reset_lesson_position`.  (Note that record field names are variable names when they appear in a pattern, e.g. `val {a, ...} = ...`.)
 1. In most SML code I've seen/worked with, whitespace in record literals [usually](http://mlton.org/FunctionalRecordUpdate) have the form
    `{a = 1, b = 2}`
    rather than
    `{ a=1, b=2 }`.